### PR TITLE
Query all

### DIFF
--- a/tests/postman/ivan_failure_flow.postman_collection.json
+++ b/tests/postman/ivan_failure_flow.postman_collection.json
@@ -227,13 +227,8 @@
 						"id": "c39c71d9-6266-4304-a905-718a3fad5582",
 						"type": "text/javascript",
 						"exec": [
-							"pm.test(\"Status code is not 200\", function () {",
-							"    pm.response.to.not.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Check Error Code\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.err_code).to.not.eql(100);",
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
 							"});",
 							""
 						]


### PR DESCRIPTION
Add support for a 'query all' operation by inputting an empty scene object in the scene query API.  For example:
{"scenes":[{}]}